### PR TITLE
multilib-dev should remain 644

### DIFF
--- a/slackConfigROOT.sh
+++ b/slackConfigROOT.sh
@@ -8,7 +8,7 @@
 ## note that some configuration options may not match
 ## depending on the system, as config-o-matic tries
 ## to avoid overwriting most files
-CONFIGOMATICVERSION=6.9.13
+CONFIGOMATICVERSION=6.9.14
 
 
 if [ ! $UID = 0 ]; then
@@ -618,7 +618,6 @@ if [ "$SPPLUSISINSTALLED" = true ]; then
     ## script to set up the environment for compat32 building
     wget -N https://raw.githubusercontent.com/ryanpcmcquen/linuxTweaks/master/slackware/multilib-dev.sh \
       -P ~/
-    chmod 755 ~/multilib-dev.sh
   fi
 fi
 


### PR DESCRIPTION
because it is sourced, not ran